### PR TITLE
@dblock Fixes podpsec version/tag disparity

### DIFF
--- a/ARTiledImageView.podspec
+++ b/ARTiledImageView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ARTiledImageView"
-  s.version          = "1.2"
+  s.version          = "1.2.0"
   s.summary          = "Display, pan and deep zoom with tiled images."
   s.description      = "Display, pan and deep zoom with tiled images on iOS."
   s.homepage         = "https://github.com/dblock/ARTiledImageView"


### PR DESCRIPTION
Tag is `1.2.0` but the tag referenced in the podspec was the same as its version, which was only `1.2`.